### PR TITLE
Use pure Go rather than C for event formatting & reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You should see these requests appear on your TraceView dashboard.
 
 ## License
 
-Copyright (c) 2013 Appneta
+Copyright (c) 2015 Appneta
 
 Released under the [AppNeta Open License](http://www.appneta.com/appneta-license), Version 1.0
 

--- a/sample_app/main.go
+++ b/sample_app/main.go
@@ -5,10 +5,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/tracelytics/go-traceview/traceview"
 	"math/rand"
 	"net/http"
 	"time"
+
+	"github.com/appneta/go-traceview/traceview"
 )
 
 // Our "app" doesn't do much:

--- a/sample_app/main.go
+++ b/sample_app/main.go
@@ -5,7 +5,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/appneta/go-traceview/traceview"
+	"github.com/tracelytics/go-traceview/traceview"
 	"math/rand"
 	"net/http"
 	"time"

--- a/traceview/bson.go
+++ b/traceview/bson.go
@@ -1,0 +1,5 @@
+package traceview
+
+type bson_buffer struct {
+	buf []byte
+}

--- a/traceview/bson.go
+++ b/traceview/bson.go
@@ -1,5 +1,112 @@
 package traceview
 
+import (
+	"math"
+)
+
 type bson_buffer struct {
 	buf []byte
+}
+
+// Conforms to C interface to simplify port
+// XXX: convert to something more go-like
+
+func bson_buffer_init(b *bson_buffer) {
+	b.buf = make([]byte, 0, 4)
+	b.reserveInt32()
+}
+
+func bson_buffer_finish(b *bson_buffer) {
+	b.addBytes(0)
+	b.setInt32(0, int32(len(b.buf)))
+}
+
+func bson_append_string(b *bson_buffer, k, v string) {
+	b.addElemName('\x02', k)
+	b.addStr(v)
+}
+
+func bson_append_int(b *bson_buffer, k string, v int) {
+	if v >= math.MinInt32 && v <= math.MaxInt32 {
+		bson_append_int32(b, k, int32(v))
+	} else {
+		bson_append_int64(b, k, int64(v))
+	}
+}
+
+func bson_append_int32(b *bson_buffer, k string, v int32) {
+	b.addElemName('\x10', k)
+	b.addInt32(v)
+}
+
+func bson_append_int64(b *bson_buffer, k string, v int64) {
+	b.addElemName('\x12', k)
+	b.addInt64(v)
+}
+
+// Based on https://github.com/go-mgo/mgo/blob/v2/bson/encodb.go
+// --------------------------------------------------------------------------
+// Marshaling of elements in a document.
+
+func (b *bson_buffer) addElemName(kind byte, name string) {
+	b.addBytes(kind)
+	b.addBytes([]byte(name)...)
+	b.addBytes(0)
+}
+
+// Marshaling of base types.
+
+func (b *bson_buffer) addBinary(subtype byte, v []byte) {
+	if subtype == 0x02 {
+		// Wonder how that brilliant idea came to lifb. Obsolete, luckily.
+		b.addInt32(int32(len(v) + 4))
+		b.addBytes(subtype)
+		b.addInt32(int32(len(v)))
+	} else {
+		b.addInt32(int32(len(v)))
+		b.addBytes(subtype)
+	}
+	b.addBytes(v...)
+}
+
+func (b *bson_buffer) addStr(v string) {
+	b.addInt32(int32(len(v) + 1))
+	b.addCStr(v)
+}
+
+func (b *bson_buffer) addCStr(v string) {
+	b.addBytes([]byte(v)...)
+	b.addBytes(0)
+}
+
+func (b *bson_buffer) reserveInt32() (pos int) {
+	pos = len(b.buf)
+	b.addBytes(0, 0, 0, 0)
+	return pos
+}
+
+func (b *bson_buffer) setInt32(pos int, v int32) {
+	b.buf[pos+0] = byte(v)
+	b.buf[pos+1] = byte(v >> 8)
+	b.buf[pos+2] = byte(v >> 16)
+	b.buf[pos+3] = byte(v >> 24)
+}
+
+func (b *bson_buffer) addInt32(v int32) {
+	u := uint32(v)
+	b.addBytes(byte(u), byte(u>>8), byte(u>>16), byte(u>>24))
+}
+
+func (b *bson_buffer) addInt64(v int64) {
+	u := uint64(v)
+	b.addBytes(byte(u), byte(u>>8), byte(u>>16), byte(u>>24),
+		byte(u>>32), byte(u>>40), byte(u>>48), byte(u>>56))
+}
+
+func (b *bson_buffer) addFloat64(v float64) {
+	b.addInt64(int64(math.Float64bits(v)))
+}
+
+func (b *bson_buffer) addBytes(v ...byte) {
+	b.buf = append(b.buf, v...)
 }

--- a/traceview/bson.go
+++ b/traceview/bson.go
@@ -44,7 +44,21 @@ func bson_append_int64(b *bson_buffer, k string, v int64) {
 	b.addInt64(v)
 }
 
-// Based on https://github.com/go-mgo/mgo/blob/v2/bson/encodb.go
+func bson_append_float64(b *bson_buffer, k string, v float64) {
+	b.addElemName('\x01', k)
+	b.addFloat64(v)
+}
+
+func bson_append_bool(b *bson_buffer, k string, v bool) {
+	b.addElemName('\x08', k)
+	if v {
+		b.addBytes(1)
+	} else {
+		b.addBytes(0)
+	}
+}
+
+// Based on https://github.com/go-mgo/mgo/blob/v2/bson/encode.go
 // --------------------------------------------------------------------------
 // Marshaling of elements in a document.
 

--- a/traceview/context.go
+++ b/traceview/context.go
@@ -215,7 +215,7 @@ func oboe_metadata_tostr(md *oboe_metadata_t, buf []byte) int {
 		return -1
 	}
 	enc := make([]byte, 2*result)
-	_ = hex.Encode(enc, buf)
+	_ = hex.Encode(enc, buf[:result])
 	copy(buf[0:2*result], enc)
 	buf[2*result] = byte(0)
 

--- a/traceview/context.go
+++ b/traceview/context.go
@@ -7,17 +7,18 @@ import (
 	"fmt"
 )
 
-const OBOE_METADATA_STRING_LEN = 58
-const MASK_TASK_ID_LEN = 0x03
-const MASK_OP_ID_LEN = 0x08
-const MASK_HAS_OPTIONS = 0x04
-const MASK_VERSION = 0xF0
+const (
+	OBOE_METADATA_STRING_LEN = 58
+	MASK_TASK_ID_LEN         = 0x03
+	MASK_OP_ID_LEN           = 0x08
+	MASK_HAS_OPTIONS         = 0x04
+	MASK_VERSION             = 0xF0
 
-const XTR_CURRENT_VERSION = 1
-
-const OBOE_MAX_TASK_ID_LEN = 20
-const OBOE_MAX_OP_ID_LEN = 8
-const OBOE_MAX_METADATA_PACK_LEN = 512
+	XTR_CURRENT_VERSION        = 1
+	OBOE_MAX_TASK_ID_LEN       = 20
+	OBOE_MAX_OP_ID_LEN         = 8
+	OBOE_MAX_METADATA_PACK_LEN = 512
+)
 
 type oboe_ids_t struct {
 	task_id []byte

--- a/traceview/context.go
+++ b/traceview/context.go
@@ -133,7 +133,7 @@ func oboe_metadata_pack(md *oboe_metadata_t, buf []byte) int {
 	buf[0] |= ((uint8(md.op_len) >> 2) - 1) << 3
 
 	copy(buf[1:1+md.task_len], md.ids.task_id)
-	copy(buf[md.task_len:md.task_len+md.op_len], md.ids.op_id)
+	copy(buf[1+md.task_len:1+md.task_len+md.op_len], md.ids.op_id)
 
 	return req_len
 }
@@ -217,7 +217,7 @@ func oboe_metadata_tostr(md *oboe_metadata_t) (string, error) {
 		return "", errors.New("buffer too small")
 	}
 	enc := make([]byte, 2*result)
-	len := hex.Encode(enc, buf[:result-1])
+	len := hex.Encode(enc, buf[:result])
 	return string(enc[:len]), nil
 }
 

--- a/traceview/context.go
+++ b/traceview/context.go
@@ -69,6 +69,17 @@ func oboe_metadata_random(md *oboe_metadata_t) {
 	}
 }
 
+func oboe_random_op_id(md *oboe_metadata_t) {
+	_, err := rand.Read(md.ids.op_id)
+	if err != nil {
+		return
+	}
+}
+
+func oboe_ids_set_op_id(ids *oboe_ids_t, op_id []byte) {
+	copy(ids.op_id, op_id)
+}
+
 /*
  * Pack a metadata struct into a buffer.
  *

--- a/traceview/context.go
+++ b/traceview/context.go
@@ -7,14 +7,6 @@ import (
 	"fmt"
 )
 
-/*
-#cgo pkg-config: openssl
-#cgo LDFLAGS: -loboe
-#include <stdlib.h>
-#include <oboe/oboe.h>
-*/
-import "C"
-
 const OBOE_METADATA_STRING_LEN = 58
 const MASK_TASK_ID_LEN = 0x03
 const MASK_OP_ID_LEN = 0x08

--- a/traceview/context.go
+++ b/traceview/context.go
@@ -221,6 +221,12 @@ func oboe_metadata_tostr(md *oboe_metadata_t) (string, error) {
 	return string(enc[:len]), nil
 }
 
+func (md *oboe_metadata_t) op_string() string {
+	enc := make([]byte, 2*md.op_len)
+	len := hex.Encode(enc, md.ids.op_id[:md.op_len])
+	return string(enc[:len])
+}
+
 // Allocates context with random metadata (new trace)
 func NewContext() *Context {
 	ctx := &Context{}

--- a/traceview/context.go
+++ b/traceview/context.go
@@ -1,8 +1,9 @@
 package traceview
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
-	"unsafe"
 )
 
 /*
@@ -13,25 +14,216 @@ import (
 */
 import "C"
 
+const OBOE_METADATA_STRING_LEN = 58
+const MASK_TASK_ID_LEN = 0x03
+const MASK_OP_ID_LEN = 0x08
+const MASK_HAS_OPTIONS = 0x04
+const MASK_VERSION = 0xF0
+
+const XTR_CURRENT_VERSION = 1
+
+const OBOE_MAX_TASK_ID_LEN = 20
+const OBOE_MAX_OP_ID_LEN = 8
+const OBOE_MAX_METADATA_PACK_LEN = 512
+
+type oboe_ids_t struct {
+	task_id []byte
+	op_id   []byte
+}
+
+type oboe_metadata_t struct {
+	ids      oboe_ids_t
+	task_len int
+	op_len   int
+}
+
 type Context struct {
-	metadata C.oboe_metadata_t
+	metadata oboe_metadata_t
+}
+
+func oboe_metadata_init(md *oboe_metadata_t) int {
+	if md == nil {
+		return -1
+	}
+
+	md.task_len = OBOE_MAX_TASK_ID_LEN
+	md.op_len = OBOE_MAX_OP_ID_LEN
+	md.ids.task_id = make([]byte, OBOE_MAX_TASK_ID_LEN)
+	md.ids.op_id = make([]byte, OBOE_MAX_TASK_ID_LEN)
+
+	return 0
+}
+
+func oboe_metadata_random(md *oboe_metadata_t) {
+	if md == nil {
+		return
+	}
+
+	_, err := rand.Read(md.ids.task_id)
+	if err != nil {
+		return
+	}
+	_, err = rand.Read(md.ids.op_id)
+	if err != nil {
+		return
+	}
+}
+
+/*
+ * Pack a metadata struct into a buffer.
+ *
+ * md       - pointer to the metadata struct
+ * task_len - the task_id length to take
+ * op_len   - the op_id length to take
+ * buf      - the buffer to pack the metadata into
+ * buf_len  - the space available in the buffer
+ *
+ * returns the length of the packed metadata, in terms of uint8_ts.
+ */
+func oboe_metadata_pack(md *oboe_metadata_t, buf []byte) int {
+	if md == nil {
+		return -1
+	}
+
+	req_len := md.task_len + md.op_len + 1
+
+	if len(buf) < req_len {
+		return -1
+	}
+
+	var task_bits byte
+
+	/*
+	 * Flag field layout:
+	 *     7    6     5     4     3     2     1     0
+	 * +-----+-----+-----+-----+-----+-----+-----+-----+
+	 * |                       |     |     |           |
+	 * |        version        | oid | opt |    tid    |
+	 * |                       |     |     |           |
+	 * +-----+-----+-----+-----+-----+-----+-----+-----+
+	 *
+	 * tid - task id length
+	 *          0 <~> 4, 1 <~> 8, 2 <~> 12, 3 <~> 20
+	 * oid - op id length
+	 *          (oid + 1) * 4
+	 * opt - are options present
+	 *
+	 * version - the version of X-Trace
+	 */
+	task_bits = (uint8(md.task_len) >> 2) - 1
+
+	buf[0] = XTR_CURRENT_VERSION << 4
+	if task_bits == 4 {
+		buf[0] |= 3
+	} else {
+		buf[0] |= task_bits
+	}
+	buf[0] |= ((uint8(md.op_len) >> 2) - 1) << 3
+
+	copy(buf[1:1+md.task_len], md.ids.task_id)
+	copy(buf[md.task_len:md.task_len+md.op_len], md.ids.op_id)
+
+	return req_len
+}
+
+func oboe_metadata_unpack(md *oboe_metadata_t, data []byte) int {
+	if md == nil {
+		return -1
+	}
+
+	if len(data) == 0 { // no header to read
+		return -1
+	}
+
+	flag := uint8(data[0])
+	var task_len, op_len int
+
+	/* don't recognize this? */
+	if (flag&MASK_VERSION)>>4 != XTR_CURRENT_VERSION {
+		return -2
+	}
+
+	task_len = (int(flag&MASK_TASK_ID_LEN) + 1) << 2
+	if task_len == 16 {
+		task_len = 20
+	}
+	op_len = ((int(flag&MASK_OP_ID_LEN) >> 3) + 1) << 2
+
+	/* do header lengths describe reality? */
+	if (task_len + op_len + 1) != len(data) {
+		return -1
+	}
+
+	md.task_len = task_len
+	md.op_len = op_len
+
+	md.ids.task_id = data[1 : 1+task_len]
+	md.ids.op_id = data[1+task_len : 1+task_len+op_len]
+
+	return 0
+}
+
+func oboe_metadata_fromstr(md *oboe_metadata_t, buf string) int {
+	if md == nil {
+		return -1
+	}
+
+	ubuf := make([]byte, OBOE_MAX_METADATA_PACK_LEN)
+
+	// a hex string's length would be an even number
+	if len(buf)%2 == 1 {
+		return -1
+	}
+
+	// check if there are more hex bytes than we want
+	if len(buf)/2 > OBOE_MAX_METADATA_PACK_LEN {
+		return -1
+	}
+
+	// invalid hex?
+	ret, err := hex.Decode(ubuf, []byte(buf))
+	if ret != len(buf)/2 || err != nil {
+		return -1
+	}
+
+	return oboe_metadata_unpack(md, ubuf)
+}
+
+func oboe_metadata_tostr(md *oboe_metadata_t, buf []byte) int {
+	if md == nil || buf == nil {
+		return -1
+	}
+
+	result := oboe_metadata_pack(md, buf)
+	if result < 0 {
+		return result
+	}
+
+	/* result is # of packed bytes */
+	if !(2*result < len(buf)) { // hex repr of md is 2*(# of packed bytes)
+		return -1
+	}
+	enc := make([]byte, 2*result)
+	_ = hex.Encode(enc, buf)
+	copy(buf[0:2*result], enc)
+	buf[2*result] = byte(0)
+
+	return 0
 }
 
 // Allocates context with random metadata (new trace)
 func NewContext() *Context {
 	ctx := &Context{}
-	C.oboe_metadata_init(&ctx.metadata)
-	C.oboe_metadata_random(&ctx.metadata)
+	oboe_metadata_init(&ctx.metadata)
+	oboe_metadata_random(&ctx.metadata)
 	return ctx
 }
 
 // Allocates context with existing metadata (for continuing traces)
 func NewContextFromMetaDataString(mdstr string) *Context {
-	var cmdstr *C.char = C.CString(mdstr)
 	ctx := &Context{}
-	C.oboe_metadata_init(&ctx.metadata)
-	C.oboe_metadata_fromstr(&ctx.metadata, cmdstr, C.size_t(len(mdstr)))
-	C.free(unsafe.Pointer(cmdstr))
+	oboe_metadata_init(&ctx.metadata)
+	oboe_metadata_fromstr(&ctx.metadata, mdstr)
 	return ctx
 }
 
@@ -44,14 +236,13 @@ func (ctx *Context) String() string {
 }
 
 // converts metadata (*oboe_metadata_t) to a string representation
-func metadataString(metadata *C.oboe_metadata_t) string {
-	buf := make([]C.char, 64)
+func metadataString(metadata *oboe_metadata_t) string {
+	buf := make([]byte, 64)
 	var md_str string
 
-	// XXX: Review: Call C function using Go-managed memory
-	rc := C.oboe_metadata_tostr(metadata, &buf[0], C.size_t(len(buf)))
+	rc := oboe_metadata_tostr(metadata, buf)
 	if rc == 0 {
-		md_str = C.GoString(&buf[0])
+		md_str = string(buf)
 	}
 
 	return md_str

--- a/traceview/cstrcache.go
+++ b/traceview/cstrcache.go
@@ -1,0 +1,42 @@
+// Caches CStrings
+// Currently used for entry layer names to avoid repetitive malloc/free of the same string.
+// We intentionally do not free here.
+// Based on http://arslan.io/thread-safe-set-data-structure-in-go
+package traceview
+
+import (
+	"C"
+	"sync"
+)
+
+type CStringCache struct {
+	m map[string]*C.char
+	sync.RWMutex
+}
+
+func NewCStringCache() *CStringCache {
+	return &CStringCache{
+		m: make(map[string]*C.char),
+	}
+}
+
+// Has looks for the existence of a string
+func (c *CStringCache) Has(str string) *C.char {
+	c.RLock()
+	defer c.RUnlock()
+	cstr := c.m[str]
+	return cstr
+}
+
+// Gets *C.char associated with a Go string
+func (c *CStringCache) Get(str string) *C.char {
+	cstr := c.Has(str)
+	if cstr == nil {
+		// Not found, need to allocate:
+		c.Lock()
+		defer c.Unlock()
+		cstr = C.CString(str)
+		c.m[str] = cstr
+	}
+	return cstr
+}

--- a/traceview/event.go
+++ b/traceview/event.go
@@ -84,6 +84,21 @@ func (e *Event) AddInt32(key string, value int32) {
 	bson_append_int32(&e.bbuf, key, value)
 }
 
+// Adds float32 key/value to event
+func (e *Event) AddFloat32(key string, value float32) {
+	bson_append_float64(&e.bbuf, key, float64(value))
+}
+
+// Adds float64 key/value to event
+func (e *Event) AddFloat64(key string, value float64) {
+	bson_append_float64(&e.bbuf, key, value)
+}
+
+// Adds float key/value to event
+func (e *Event) AddBool(key string, value bool) {
+	bson_append_bool(&e.bbuf, key, value)
+}
+
 // Adds edge (reference to previous event) to event
 func (e *Event) AddEdge(ctx *Context) {
 	bson_append_string(&e.bbuf, "Edge", ctx.metadata.op_string())

--- a/traceview/event.go
+++ b/traceview/event.go
@@ -86,14 +86,14 @@ func (e *Event) AddInt32(key string, value int32) {
 
 // Adds edge (reference to previous event) to event
 func (e *Event) AddEdge(ctx *Context) {
-	bson_append_string(&e.bbuf, "Edge", metadataString(&ctx.metadata))
+	bson_append_string(&e.bbuf, "Edge", ctx.metadata.op_string())
 }
 
 func (e *Event) AddEdgeFromMetaDataString(mdstr string) {
 	var md oboe_metadata_t
 	oboe_metadata_init(&md)
 	oboe_metadata_fromstr(&md, mdstr)
-	bson_append_string(&e.bbuf, "Edge", metadataString(&md))
+	bson_append_string(&e.bbuf, "Edge", md.op_string())
 }
 
 // Reports event using specified Reporter

--- a/traceview/event.go
+++ b/traceview/event.go
@@ -20,10 +20,8 @@ const (
 
 func oboe_event_init(evt *Event, md *oboe_metadata_t) int {
 	var result int
-	md_buf := make([]byte, 64)
 
 	// Metadata initialization
-
 	result = oboe_metadata_init(&evt.metadata)
 	if result < 0 {
 		return result
@@ -44,8 +42,10 @@ func oboe_event_init(evt *Event, md *oboe_metadata_t) int {
 	bson_append_string(&evt.bbuf, "_V", EventHeader)
 
 	// Pack metadata
-	oboe_metadata_tostr(&evt.metadata, md_buf) // XXX: probably should just return a string ...
-	bson_append_string(&evt.bbuf, "X-Trace", string(md_buf))
+	md_str, err := oboe_metadata_tostr(&evt.metadata)
+	if err == nil {
+		bson_append_string(&evt.bbuf, "X-Trace", md_str)
+	}
 
 	return 0
 }

--- a/traceview/event_test.go
+++ b/traceview/event_test.go
@@ -15,6 +15,10 @@ func TestSendEvent(t *testing.T) {
 		t.Errorf("Unexpected %v", err)
 	}
 
+	ctx.ReportEvent("info", test_layer,
+		"Controller", "test_controller",
+		"Action", "test_action")
+
 	e = ctx.NewEvent(LabelExit, test_layer)
 	e.AddEdge(ctx)
 	if err := e.Report(ctx); err != nil {

--- a/traceview/reporter.go
+++ b/traceview/reporter.go
@@ -16,7 +16,7 @@ func NewUDPReporter() *Reporter {
 	// XXX: make connection configurable?
 	var conn *net.UDPConn
 	serverAddr, err := net.ResolveUDPAddr("udp4", "127.0.0.1:7831")
-	if err != nil {
+	if err == nil {
 		conn, err = net.DialUDP("udp4", nil, serverAddr)
 	}
 	if err != nil {

--- a/traceview/reporter.go
+++ b/traceview/reporter.go
@@ -1,42 +1,59 @@
 package traceview
 
 import (
-	"errors"
-	"fmt"
 	"log"
-	"unsafe"
+	"net"
+	"os"
+	"time"
 )
 
-/*
-#include <stdlib.h>
-#include <oboe/oboe.h>
-*/
-import "C"
-
+// XXX: make this an interface ...
 type Reporter struct {
-	reporter C.oboe_reporter_t
+	conn *net.UDPConn
 }
 
 func NewUDPReporter() *Reporter {
-	r := Reporter{}
-	var host *C.char = C.CString("127.0.0.1")
-	var port *C.char = C.CString("7831")
-
-	if C.oboe_reporter_udp_init(&r.reporter, host, port) < 0 {
-		log.Printf("Failed to initialize UDP reporter")
+	// XXX: make connection configurable?
+	var conn *net.UDPConn
+	serverAddr, err := net.ResolveUDPAddr("udp4", "127.0.0.1:7831")
+	if err != nil {
+		conn, err = net.DialUDP("udp4", nil, serverAddr)
 	}
-
-	C.free(unsafe.Pointer(host))
-	C.free(unsafe.Pointer(port))
-
-	return &r
+	if err != nil {
+		log.Printf("Failed to initialize UDP reporter: %v", err)
+	}
+	return &Reporter{conn}
 }
 
 func (r *Reporter) ReportEvent(ctx *Context, e *Event) error {
-	var err error
-	rc := C.oboe_reporter_send(&r.reporter, &ctx.metadata, &e.event)
-	if rc < 0 {
-		err = errors.New(fmt.Sprintf("Error Reporting Event: %v", int(rc)))
+	if r.conn == nil {
+		// Reporter didn't initialize, nothing to do...
+		return nil
+	}
+
+	// XXX add validation from oboe_reporter_send
+
+	us := time.Now().UnixNano() / 1000
+	e.AddInt64("Timestamp_u", us)
+
+	// XXX could cache hostname and PID:
+	hostname, err := os.Hostname()
+	if err != nil {
+		log.Println("Unable to get hostname: %v", err)
+		return err
+	}
+	e.AddString("Hostname", hostname)
+	e.AddInt("PID", os.Getpid())
+
+	// Update the context's op_id to that of the event
+	oboe_ids_set_op_id(&ctx.metadata.ids, e.metadata.ids.op_id)
+
+	// Send BSON:
+	bson_buffer_finish(&e.bbuf)
+	_, err = r.conn.Write(e.bbuf.buf)
+	if err != nil {
+		log.Printf("Unable to send event: %v", err)
+		return err
 	}
 	return err
 }

--- a/traceview/traceview.go
+++ b/traceview/traceview.go
@@ -8,6 +8,8 @@ import (
 )
 
 /*
+#cgo pkg-config: openssl
+#cgo LDFLAGS: -loboe
 #include <stdlib.h>
 #include <oboe/oboe.h>
 */
@@ -46,6 +48,7 @@ func init() {
 }
 
 // Determines if request should be traced, based on sample rate settings:
+// This is our only dependency on the liboboe C library
 func ShouldTraceRequest(layer, xtrace_header string) (bool, int, int) {
 	var sample_rate, sample_source C.int
 	var clayer *C.char = C.CString(layer)


### PR DESCRIPTION
This replaces almost all the calls into C code for creating, manipulating, and reporting event data and metadata with pure Go implementations, to reduce dependencies on C strings, cgo, and C memory allocations.  The "liboboe" C instrumentation library is used only for reading configuration settings from TraceView.