### PR TITLE
Fix reporting & test of init message

### DIFF
--- a/v1/tv/internal/graphtest/graph.go
+++ b/v1/tv/internal/graphtest/graph.go
@@ -131,14 +131,21 @@ func AssertGraph(t *testing.T, bufs [][]byte, numNodes int, nodeMap map[MatchNod
 func assertOutEdges(t *testing.T, g eventGraph, n Node, edges ...MatchNode) {
 	assert.Equal(t, len(n.Edges), len(edges),
 		"[layer %s label %s] len(n.Edges) %d expected %d", n.Layer, n.Label, len(n.Edges), len(edges))
+	foundEdges := 0
 	if len(edges) <= len(n.Edges) {
 		for i, edge := range edges {
+			_, ok := g[n.Edges[i]] // check if node for this edge exists
+			assert.True(t, ok, "Edge from {%s, %s} missing to {%s, %s} no node %d", n.Layer, n.Label, edge.Layer, edge.Label, i)
 			assert.Equal(t, edge.Layer, g[n.Edges[i]].Layer,
 				"Edge from {%s, %s} missing to {%s, %s} actual %d {%s, %s}", n.Layer, n.Label, edge.Layer, edge.Label, i, g[n.Edges[i]].Layer, g[n.Edges[i]].Label)
 			assert.Equal(t, edge.Label, g[n.Edges[i]].Label,
 				"Edge from {%s, %s} missing to {%s, %s} actual %d {%s, %s}", n.Layer, n.Label, edge.Layer, edge.Label, i, g[n.Edges[i]].Layer, g[n.Edges[i]].Label)
+			if edge.Layer == g[n.Edges[i]].Layer && edge.Label == g[n.Edges[i]].Label {
+				foundEdges++
+			}
 			checkedEdges++
 		}
+		assert.Equal(t, foundEdges, len(edges))
 	}
 }
 

--- a/v1/tv/internal/traceview/oboe.go
+++ b/v1/tv/internal/traceview/oboe.go
@@ -62,7 +62,8 @@ var initOnce sync.Once
 
 func sendInitMessage() {
 	ctx := NewContext()
-	ctx.ReportEvent(LabelEntry, initLayer, "__Init", 1,
+	ctx.reportEvent(LabelEntry, initLayer, false,
+		"__Init", 1,
 		"Go.Version", runtime.Version(),
 		"Go.Oboe.Version", initVersion,
 		"Oboe.Version", oboeVersion,

--- a/v1/tv/internal/traceview/oboe_test.go
+++ b/v1/tv/internal/traceview/oboe_test.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	g "github.com/appneta/go-traceview/v1/tv/internal/graphtest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInitMessage(t *testing.T) {
@@ -18,7 +18,7 @@ func TestInitMessage(t *testing.T) {
 	sendInitMessage()
 
 	g.AssertGraph(t, r.Bufs, 2, map[g.MatchNode]g.AssertNode{
-		{"go", "entry"}: {g.OutEdges{{}}, func(n g.Node) {
+		{"go", "entry"}: {g.OutEdges{}, func(n g.Node) {
 			assert.Equal(t, 1, n.Map["__Init"])
 			assert.Equal(t, initVersion, n.Map["Go.Oboe.Version"])
 			assert.NotEmpty(t, n.Map["Oboe.Version"])


### PR DESCRIPTION
This fixes a bug in the format of the init message that each server sends us when TraceView is enabled and it first starts tracing.