### PR TITLE
Fix observation of HTTP Status in tv.HTTPHandler

### DIFF
--- a/v1/tv/http_instrumentation.go
+++ b/v1/tv/http_instrumentation.go
@@ -27,14 +27,14 @@ func HTTPHandler(handler func(http.ResponseWriter, *http.Request)) func(http.Res
 		}
 
 		// wrap writer with status-observing writer
-		writer := httpResponseWriter{w, http.StatusOK}
-		w = writer
+		status := http.StatusOK
+		w = httpResponseWriter{w, &status}
 
 		// Add status code and report exit event
-		defer t.EndCallback(func() KVMap { return KVMap{"Status": writer.status} })
+		defer t.EndCallback(func() KVMap { return KVMap{"Status": status} })
 
 		// Call original HTTP handler:
-		handler(writer, r)
+		handler(w, r)
 	}
 }
 
@@ -42,10 +42,10 @@ func HTTPHandler(handler func(http.ResponseWriter, *http.Request)) func(http.Res
 // the HTTP status code.
 type httpResponseWriter struct {
 	http.ResponseWriter
-	status int
+	status *int
 }
 
 func (w httpResponseWriter) WriteHeader(status int) {
 	w.ResponseWriter.WriteHeader(status)
-	w.status = status
+	*w.status = status
 }

--- a/v1/tv/http_instrumentation_test.go
+++ b/v1/tv/http_instrumentation_test.go
@@ -13,13 +13,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func httpTest() *httptest.ResponseRecorder {
-	// create & wrap 404 handler
-	f := func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(404)
-	}
-	h := http.HandlerFunc(tv.HTTPHandler(f))
+func handler404(w http.ResponseWriter, r *http.Request) { w.WriteHeader(404) }
+func handler200(w http.ResponseWriter, r *http.Request) {} // do nothing (default should be 200)
 
+func httpTest(f http.HandlerFunc) *httptest.ResponseRecorder {
+	h := http.HandlerFunc(tv.HTTPHandler(f))
 	// test a single GET request
 	req, _ := http.NewRequest("GET", "", nil)
 	w := httptest.NewRecorder()
@@ -27,9 +25,9 @@ func httpTest() *httptest.ResponseRecorder {
 	return w
 }
 
-func TestHTTPHandler(t *testing.T) {
+func TestHTTPHandler404(t *testing.T) {
 	r := traceview.SetTestReporter() // set up test reporter
-	response := httpTest()
+	response := httpTest(handler404)
 
 	g.AssertGraph(t, r.Bufs, 2, map[g.MatchNode]g.AssertNode{
 		// entry event should have no edges
@@ -44,10 +42,27 @@ func TestHTTPHandler(t *testing.T) {
 	})
 }
 
+func TestHTTPHandler200(t *testing.T) {
+	r := traceview.SetTestReporter() // set up test reporter
+	response := httpTest(handler200)
+
+	g.AssertGraph(t, r.Bufs, 2, map[g.MatchNode]g.AssertNode{
+		// entry event should have no edges
+		{"net/http", "entry"}: {},
+		{"net/http", "exit"}: {g.OutEdges{{"net/http", "entry"}}, func(n g.Node) {
+			// assert that response X-Trace header matches trace exit event
+			assert.Len(t, response.HeaderMap["X-Trace"], 1)
+			assert.Equal(t, response.HeaderMap["X-Trace"][0], n.Map["X-Trace"])
+			assert.EqualValues(t, response.Code, n.Map["Status"])
+			assert.EqualValues(t, 200, n.Map["Status"])
+		}},
+	})
+}
+
 func TestHTTPHandlerNoTrace(t *testing.T) {
 	r := traceview.SetTestReporter() // set up test reporter
 	r.ShouldTrace = false
-	httpTest()
+	httpTest(handler404)
 
 	// tracing disabled, shouldn't report anything
 	assert.Len(t, r.Bufs, 0)

--- a/v1/tv/http_instrumentation_test.go
+++ b/v1/tv/http_instrumentation_test.go
@@ -19,8 +19,6 @@ func httpTest() *httptest.ResponseRecorder {
 		w.WriteHeader(404)
 	}
 	h := http.HandlerFunc(tv.HTTPHandler(f))
-	//sm := http.NewServeMux()
-	//sm.HandleFunc("/", h)
 
 	// test a single GET request
 	req, _ := http.NewRequest("GET", "", nil)
@@ -40,6 +38,8 @@ func TestHTTPHandler(t *testing.T) {
 			// assert that response X-Trace header matches trace exit event
 			assert.Len(t, response.HeaderMap["X-Trace"], 1)
 			assert.Equal(t, response.HeaderMap["X-Trace"][0], n.Map["X-Trace"])
+			assert.EqualValues(t, response.Code, n.Map["Status"])
+			assert.EqualValues(t, 404, n.Map["Status"])
 		}},
 	})
 }


### PR DESCRIPTION
This fixes the http.ResponseWriter implementation (contributed in #3, but broken by me) in our HTTPHandler wrapper to correctly observe the status. It also adds tests to check the status code reported by 200- and 404-returning handlers.